### PR TITLE
Don't use quotes around settings

### DIFF
--- a/library/src/main/java/hu/supercluster/overpasser/library/query/OverpassQuery.java
+++ b/library/src/main/java/hu/supercluster/overpasser/library/query/OverpassQuery.java
@@ -34,7 +34,7 @@ public class OverpassQuery extends AbstractOverpassQuery {
      * @return the current OverpassQuery object
      */
     public OverpassQuery format(OutputFormat outputFormat) {
-        builder.clause("out", outputFormat.toString().toLowerCase());
+        builder.setting("out", outputFormat.toString().toLowerCase());
 
         return this;
     }
@@ -50,7 +50,7 @@ public class OverpassQuery extends AbstractOverpassQuery {
      * @return the current OverpassQuery object
      */
     public OverpassQuery timeout(int timeout) {
-        builder.clause("timeout", "" + timeout);
+        builder.setting("timeout", "" + timeout);
 
         return this;
     }

--- a/library/src/main/java/hu/supercluster/overpasser/library/query/OverpassQueryBuilder.java
+++ b/library/src/main/java/hu/supercluster/overpasser/library/query/OverpassQueryBuilder.java
@@ -5,6 +5,7 @@ import java.util.Set;
 interface OverpassQueryBuilder {
     OverpassQueryBuilder append(String statement);
     OverpassQueryBuilder boundingBox(double lat1, double lon1, double lat2, double lon2);
+    OverpassQueryBuilder setting(String name, String value);
     OverpassQueryBuilder standaloneParam(String name);
     OverpassQueryBuilder clause(String name, String value);
     OverpassQueryBuilder equals(String name, String value);

--- a/library/src/main/java/hu/supercluster/overpasser/library/query/OverpassQueryBuilderImpl.java
+++ b/library/src/main/java/hu/supercluster/overpasser/library/query/OverpassQueryBuilderImpl.java
@@ -19,12 +19,18 @@ class OverpassQueryBuilderImpl implements OverpassQueryBuilder {
     }
 
     private OverpassQueryBuilder paramRel(String name, String rel, String value) {
+        return paramRel(name, rel, value, true);
+    }
+
+    private OverpassQueryBuilder paramRel(String name, String rel, String value, boolean quoteName) {
         String quotedValue = value.isEmpty() ? "" : String.format("\"%s\"", value);
+
+        String pattern = quoteName ? "[\"%s\"%s%s]" : "[%s%s%s]";
 
         return append(
                 String.format(
                         LOCALE,
-                        "[\"%s\"%s%s]",
+                        pattern,
                         name, rel, quotedValue
                 )
         );
@@ -39,6 +45,11 @@ class OverpassQueryBuilderImpl implements OverpassQueryBuilder {
                         lat1, lon1, lat2, lon2
                 )
         );
+    }
+
+    @Override
+    public OverpassQueryBuilder setting(String name, String value) {
+        return paramRel(name, ":", value, false);
     }
 
     @Override

--- a/library/src/test/java/hu/supercluster/overpasser/library/query/OverpassQueryTest.java
+++ b/library/src/test/java/hu/supercluster/overpasser/library/query/OverpassQueryTest.java
@@ -38,14 +38,14 @@ public class OverpassQueryTest {
     public void testFormat() throws Exception {
         query.format(JSON);
 
-        verify(builder).clause("out", "json");
+        verify(builder).setting("out", "json");
     }
 
     @Test
     public void testTimeout() throws Exception {
         query.timeout(30);
 
-        verify(builder).clause("timeout", "30");
+        verify(builder).setting("timeout", "30");
     }
 
     @Test

--- a/library/src/test/java/hu/supercluster/overpasser/library/query/UsageExamplesTest.java
+++ b/library/src/test/java/hu/supercluster/overpasser/library/query/UsageExamplesTest.java
@@ -43,7 +43,7 @@ public class UsageExamplesTest {
                 .build()
         ;
 
-        String expected = "[\"out\":\"json\"][\"timeout\":\"30\"]; (node[\"amenity\"=\"parking\"][\"access\"!=\"private\"](47.48047027491862,19.039797484874725,47.51331674014172,19.07404761761427);<;); out body center qt 100;";
+        String expected = "[out:\"json\"][timeout:\"30\"]; (node[\"amenity\"=\"parking\"][\"access\"!=\"private\"](47.48047027491862,19.039797484874725,47.51331674014172,19.07404761761427);<;); out body center qt 100;";
 
         assertEquals(expected, result);
     }
@@ -82,7 +82,7 @@ public class UsageExamplesTest {
                 .build()
         ;
 
-        String expected = "[\"out\":\"json\"][\"timeout\":\"30\"]; ("
+        String expected = "[out:\"json\"][timeout:\"30\"]; ("
                 + "node[\"amenity\"=\"parking\"][\"access\"!=\"private\"](47.48047027491862,19.039797484874725,47.51331674014172,19.07404761761427); "
                 + "way[\"amenity\"=\"parking\"][\"access\"!=\"private\"](47.48047027491862,19.039797484874725,47.51331674014172,19.07404761761427); "
                 + "rel[\"amenity\"=\"parking\"][\"access\"!=\"private\"](47.48047027491862,19.039797484874725,47.51331674014172,19.07404761761427)"
@@ -114,7 +114,7 @@ public class UsageExamplesTest {
                 .build()
                 ;
 
-        String expected = "[\"out\":\"json\"][\"timeout\":\"30\"]"
+        String expected = "[out:\"json\"][timeout:\"30\"]"
                 + "[bbox:47.48047027491862,19.039797484874725,47.51331674014172,19.07404761761427]"
                 + "; ("
                 + "node[\"amenity\"=\"parking\"][\"access\"!=\"private\"]; "


### PR DESCRIPTION
Introduce a setting() method in OverpassQueryBuilder and its
implementation that is used for settings instead of the clause() method.